### PR TITLE
Remove custom props from being passed to the native video component

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -111,7 +111,7 @@ export default class ReactVideo extends React.Component {
    */
   getBuffered () {
     const vid = this.refs.ReactVideo;
-    
+
     return vid.buffured;
   }
 
@@ -143,7 +143,7 @@ export default class ReactVideo extends React.Component {
 
   /**
    * Set the current volume of the media.
-   * @param {number} volume, Specifies the current volume of the audio/video. Must be a number between 0.0 and 1.0. 
+   * @param {number} volume, Specifies the current volume of the audio/video. Must be a number between 0.0 and 1.0.
    */
   setVolume (volume) {
     this.setState({volume: volume});
@@ -166,7 +166,7 @@ export default class ReactVideo extends React.Component {
     this.setState({
       playbackRate: rate
     });
- 
+
     this.setState({
       playbackRate: this.getPlaybackRate()
     });
@@ -184,10 +184,11 @@ export default class ReactVideo extends React.Component {
   }
 
   render () {
-    const { notSupportedMessage, cls, source } = this.props;
+    const {notSupportedMessage, cls, source, posterUrl, ...props} = this.props;
+    const className = cls ? `video ${cls}` : `video`;
 
     return (
-      <video ref={'ReactVideo'} className={`video ${cls}`} {...this.props}>
+      <video ref={'ReactVideo'} className={className} {...props}>
         {notSupportedMessage}
         {source.map((item, i) => {
           return (


### PR DESCRIPTION
Since React 15.2, there's a new Unknown Prop Warning [docs](https://facebook.github.io/react/warnings/unknown-prop.html). In this PR, I've removed the custom props from being passed to the native `video` component.

![image](https://cloud.githubusercontent.com/assets/1435378/20233686/2079c926-a827-11e6-9577-33c8abc818a7.png)

Also, if you currently don't specify a `cls` prop, then `undefined` is added. I fixed that in this PR as well.

![image](https://cloud.githubusercontent.com/assets/1435378/20233704/58ee3ff8-a827-11e6-9cfa-599b7fbffbcd.png)

Thanks for taking a look!